### PR TITLE
Yet more client cleanup/improvement

### DIFF
--- a/marathon_acme/clients.py
+++ b/marathon_acme/clients.py
@@ -113,10 +113,9 @@ class JsonClient(object):
 
         # Take the userinfo out of the URL and pass as 'auth' to treq so it can
         # be used for HTTP basic auth headers
-        if 'auth' not in kwargs:
-            if userinfo is not None:
-                # treq expects a 2-tuple (username, password)
-                kwargs['auth'] = tuple(userinfo.split(':', 2))
+        if 'auth' not in kwargs and userinfo is not None:
+            # treq expects a 2-tuple (username, password)
+            kwargs['auth'] = tuple(userinfo.split(':', 2))
 
         return uricompose(**compose_kwargs)
 

--- a/marathon_acme/clients.py
+++ b/marathon_acme/clients.py
@@ -165,13 +165,6 @@ class JsonClient(object):
 
         return d
 
-    def get_json(self, **kwargs):
-        """
-        Perform a GET request to the given path and return the JSON response.
-        """
-        d = self.request('GET', **kwargs)
-        return d.addCallback(json_content)
-
 
 class MarathonClient(JsonClient):
 

--- a/marathon_acme/clients.py
+++ b/marathon_acme/clients.py
@@ -93,26 +93,22 @@ class JsonClient(object):
         if url is None:
             url = self.url
 
-        compose_kwargs = {}
         if url is not None:
             split_result = urisplit(url)
-            compose_kwargs.update({
-                'scheme': split_result.scheme,
-                'host': split_result.host,
-                'port': split_result.port,
-                'path': split_result.path,
-                'query': split_result.query,
-                'fragment': split_result.fragment
-            })
             userinfo = split_result.userinfo
 
-        # Override any things specified in kwargs
-        for key in ['scheme', 'path', 'fragment', 'host', 'port']:
+        # Build up the kwargs to pass to uricompose
+        compose_kwargs = {}
+        for key in ['scheme', 'host', 'port', 'path', 'fragment']:
             if key in kwargs:
                 compose_kwargs[key] = kwargs.pop(key)
+            elif split_result is not None:
+                compose_kwargs[key] = getattr(split_result, key)
 
         if 'params' in kwargs:
             compose_kwargs['query'] = kwargs.pop('params')
+        elif split_result is not None:
+            compose_kwargs['query'] = split_result.query
 
         # Take the userinfo out of the URL and pass as 'auth' to treq so it can
         # be used for HTTP basic auth headers

--- a/marathon_acme/tests/test_clients.py
+++ b/marathon_acme/tests/test_clients.py
@@ -115,23 +115,6 @@ class JsonClientTest(JsonClientTestBase):
         request.finish()
 
     @inlineCallbacks
-    def test_get_json(self):
-        """
-        When the get_json method is called, a GET request should be made and
-        the response should be deserialized from JSON.
-        """
-        d = self.cleanup_d(self.client.get_json(path='/hello'))
-
-        request = yield self.requests.get()
-        self.assertThat(request, HasRequestProperties(
-            method='GET', url=self.uri('/hello')))
-
-        json_response(request, {'test': 'hello'})
-
-        res = yield d
-        self.assertThat(res, Equals({'test': 'hello'}))
-
-    @inlineCallbacks
     def test_client_error_response(self):
         """
         When a request is made and the raise_for_status callback is added and a

--- a/marathon_acme/tests/test_clients.py
+++ b/marathon_acme/tests/test_clients.py
@@ -1,6 +1,6 @@
 import testtools
 
-from twisted.internet import reactor as _reactor
+from twisted.internet import reactor
 from twisted.internet.task import Clock
 from twisted.internet.defer import inlineCallbacks, DeferredQueue
 from twisted.web.client import Agent
@@ -33,16 +33,16 @@ class DefaultReactorTest(testtools.TestCase):
         """
         When default_reactor is passed a reactor it should return that reactor.
         """
-        reactor = Clock()
+        clock = Clock()
 
-        self.assertThat(default_reactor(reactor), Is(reactor))
+        self.assertThat(default_reactor(clock), Is(clock))
 
     def test_default_reactor_not_provided(self):
         """
         When default_reactor is not passed a reactor, it should return the
         default reactor.
         """
-        self.assertThat(default_reactor(None), Is(_reactor))
+        self.assertThat(default_reactor(None), Is(reactor))
 
 
 class DefaultAgentTest(testtools.TestCase):
@@ -50,7 +50,6 @@ class DefaultAgentTest(testtools.TestCase):
         """
         When default_agent is passed an agent it should return that agent.
         """
-        reactor = Clock()
         agent = Agent(reactor)
 
         self.assertThat(default_agent(agent, reactor), Is(agent))
@@ -60,8 +59,6 @@ class DefaultAgentTest(testtools.TestCase):
         When default_agent is not passed an agent, it should return a default
         agent.
         """
-        reactor = Clock()
-
         self.assertThat(default_agent(None, reactor), IsInstance(Agent))
 
 

--- a/marathon_acme/tests/test_clients.py
+++ b/marathon_acme/tests/test_clients.py
@@ -39,7 +39,7 @@ class JsonClientTestBase(TestCase):
         raise NotImplementedError()
 
     def uri(self, path):
-        return '%s%s' % (self.client.endpoint.geturi(), path,)
+        return '%s%s' % (self.client.url, path,)
 
     def cleanup_d(self, d):
         self.addCleanup(lambda: d)
@@ -58,7 +58,7 @@ class JsonClientTest(JsonClientTestBase):
         address and headers, and should contain an empty body. The response
         should be returned.
         """
-        d = self.cleanup_d(self.client.request('GET', '/hello'))
+        d = self.cleanup_d(self.client.request('GET', path='/hello'))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
@@ -83,7 +83,7 @@ class JsonClientTest(JsonClientTestBase):
         indicate this.
         """
         self.cleanup_d(self.client.request(
-            'GET', '/hello', json_data={'test': 'hello'}))
+            'GET', path='/hello', json_data={'test': 'hello'}))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
@@ -98,13 +98,13 @@ class JsonClientTest(JsonClientTestBase):
         request.finish()
 
     @inlineCallbacks
-    def test_request_endpoint(self):
+    def test_request_url(self):
         """
-        When a request is made with the endpoint parameter set, that parameter
-        should be used as the endpoint.
+        When a request is made with the url parameter set, that parameter
+        should be used as the base URL.
         """
         self.cleanup_d(self.client.request(
-            'GET', '/hello', endpoint='http://localhost:9000'))
+            'GET', path='/hello', url='http://localhost:9000'))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
@@ -119,7 +119,7 @@ class JsonClientTest(JsonClientTestBase):
         When the get_json method is called, a GET request should be made and
         the response should be deserialized from JSON.
         """
-        d = self.cleanup_d(self.client.get_json('/hello'))
+        d = self.cleanup_d(self.client.get_json(path='/hello'))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
@@ -138,7 +138,7 @@ class JsonClientTest(JsonClientTestBase):
         error.
         """
         d = self.cleanup_d(self.client.request(
-            'GET', '/hello', raise_for_status=True))
+            'GET', path='/hello', raise_for_status=True))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
@@ -160,7 +160,7 @@ class JsonClientTest(JsonClientTestBase):
         error.
         """
         d = self.cleanup_d(self.client.request(
-            'GET', '/hello', raise_for_status=True))
+            'GET', path='/hello', raise_for_status=True))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
@@ -180,7 +180,7 @@ class JsonClientTest(JsonClientTestBase):
         When raise_for_status is False and a request is made and a error
         response code is returned, no error should be raised.
         """
-        d = self.cleanup_d(self.client.request('GET', '/hello'))
+        d = self.cleanup_d(self.client.request('GET', path='/hello'))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
@@ -208,7 +208,8 @@ class MarathonClientTest(JsonClientTestBase):
         deserialized from JSON and the value of the specified field is
         returned.
         """
-        d = self.cleanup_d(self.client.get_json_field('/my-path', 'field-key'))
+        d = self.cleanup_d(
+            self.client.get_json_field('field-key', path='/my-path'))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
@@ -228,7 +229,8 @@ class MarathonClientTest(JsonClientTestBase):
         When get_json_field is used to make a request but the response code
         indicates an error, an HTTPError should be raised.
         """
-        d = self.cleanup_d(self.client.get_json_field('/my-path', 'field-key'))
+        d = self.cleanup_d(
+            self.client.get_json_field('field-key', path='/my-path'))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
@@ -249,7 +251,8 @@ class MarathonClientTest(JsonClientTestBase):
         deserialized from JSON and if the specified field is missing, an error
         is raised.
         """
-        d = self.cleanup_d(self.client.get_json_field('/my-path', 'field-key'))
+        d = self.cleanup_d(
+            self.client.get_json_field('field-key', path='/my-path'))
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(

--- a/marathon_acme/tests/test_fake_marathon.py
+++ b/marathon_acme/tests/test_fake_marathon.py
@@ -199,7 +199,7 @@ class TestFakeMarathonAPI(TestCase):
 
         response = yield self.client.request(
             'POST', '/v2/eventSubscriptions',
-            query={'callbackUrl': callback_url})
+            params={'callbackUrl': callback_url})
         self.assertThat(response, IsJsonResponseWithCode(200))
 
         response_json = yield json_content(response)
@@ -228,7 +228,7 @@ class TestFakeMarathonAPI(TestCase):
 
         response = yield self.client.request(
             'POST', '/v2/eventSubscriptions',
-            query={'callbackUrl': callback_url})
+            params={'callbackUrl': callback_url})
         self.assertThat(response, IsJsonResponseWithCode(200))
 
         self.assertThat(self.marathon.get_event_subscriptions(),
@@ -236,7 +236,7 @@ class TestFakeMarathonAPI(TestCase):
 
         response = yield self.client.request(
             'POST', '/v2/eventSubscriptions',
-            query={'callbackUrl': callback_url})
+            params={'callbackUrl': callback_url})
         self.assertThat(response, IsJsonResponseWithCode(200))
 
         self.assertThat(self.marathon.get_event_subscriptions(),
@@ -254,7 +254,7 @@ class TestFakeMarathonAPI(TestCase):
 
         response = yield self.client.request(
             'DELETE', '/v2/eventSubscriptions',
-            query={'callbackUrl': callback_url})
+            params={'callbackUrl': callback_url})
         self.assertThat(response, IsJsonResponseWithCode(200))
 
         response_json = yield json_content(response)
@@ -284,7 +284,7 @@ class TestFakeMarathonAPI(TestCase):
 
         response = yield self.client.request(
             'DELETE', '/v2/eventSubscriptions',
-            query={'callbackUrl': callback_url})
+            params={'callbackUrl': callback_url})
         self.assertThat(response, IsJsonResponseWithCode(200))
 
         self.assertThat(self.marathon.get_event_subscriptions(),
@@ -292,7 +292,7 @@ class TestFakeMarathonAPI(TestCase):
 
         response = yield self.client.request(
             'DELETE', '/v2/eventSubscriptions',
-            query={'callbackUrl': callback_url})
+            params={'callbackUrl': callback_url})
         self.assertThat(response, IsJsonResponseWithCode(200))
 
         self.assertThat(self.marathon.get_event_subscriptions(),


### PR DESCRIPTION
* Change the API to be more Requests-like -- necessary to be able to reuse client for Marathon event bus
* Use a single treq client/twisted agent for all requests for a given client -- this is just because I keep digging into how treq works and not really liking the answers :/