### PR TITLE
FakeMarathon: add task status update

### DIFF
--- a/marathon_acme/tests/fake_marathon.py
+++ b/marathon_acme/tests/fake_marathon.py
@@ -58,6 +58,24 @@ class FakeMarathon(object):
 
         return [self._tasks[task_id] for task_id in task_ids]
 
+    def update_task_status(self, task_id, status):
+        assert task_id in self._tasks
+        task = self._tasks[task_id]
+
+        # Update the task status
+        task['status'] = status
+
+        # Trigger an event
+        self.trigger_event(
+            'status_update_event',
+            taskId=task_id,
+            taskStatus=status,
+            appId=task['appId'],
+            slaveId=task['slaveId'],
+            host=task['host'],
+            ports=task['ports'],
+            version=task['version'])
+
     def get_event_subscriptions(self):
         return self.event_subscriptions
 


### PR DESCRIPTION
* Trigger event when status updated

Now that I think about it we might not even need this... this is just what we do in Consular. It might make more sense to track app create/update/delete operations. We just need to track apps and their labels.