### PR TITLE
Refactor clients to take a Treq client in their constructors

### DIFF
--- a/marathon_acme/clients.py
+++ b/marathon_acme/clients.py
@@ -84,24 +84,23 @@ def default_reactor(reactor):
     return reactor
 
 
-def default_agent(agent, reactor):
+def default_client(client, reactor):
     """
-    Set up a default agent if one is not provided. Use a default reactor to do
-    so, unless one is not provided. The agent will set up a default
-    (non-persistent) connection pool if one is not provided.
+    Set up a default client if one is not provided. Set up the default
+    ``twisted.web.client.Agent`` using the provided reactor.
     """
-    if agent is None:
+    if client is None:
         from twisted.web.client import Agent
-        agent = Agent(reactor)
+        client = treq_HTTPClient(Agent(reactor))
 
-    return agent
+    return client
 
 
 class HTTPClient(object):
     debug = False
     timeout = 5
 
-    def __init__(self, url=None, agent=None, reactor=None):
+    def __init__(self, url=None, client=None, reactor=None):
         """
         Create a client with the specified default URL.
         """
@@ -109,7 +108,7 @@ class HTTPClient(object):
         # Keep track of the reactor because treq uses it for timeouts in a
         # clumsy way
         self._reactor = default_reactor(reactor)
-        self._client = treq_HTTPClient(default_agent(agent, self._reactor))
+        self._client = default_client(client, self._reactor)
 
     def _log_request_response(self, response, method, path, kwargs):
         log.msg('%s %s with args %s returned: %s' % (

--- a/marathon_acme/tests/helpers.py
+++ b/marathon_acme/tests/helpers.py
@@ -2,7 +2,12 @@ import testtools
 
 from testtools.twistedsupport import AsynchronousDeferredRunTest
 
+from treq.client import HTTPClient
+
 from twisted.web.client import ProxyAgent, URI
+from twisted.web.server import Site
+
+from txfake import FakeServer
 
 
 class TestCase(testtools.TestCase):
@@ -21,3 +26,13 @@ class FakeServerAgent(ProxyAgent):
         return self._requestWithEndpoint(
             key, self._proxyEndpoint, method, parsedURI, headers,
             bodyProducer, parsedURI.originForm)
+
+
+def fake_client(resource):
+    """
+    Build a Treq HTTPClient aroudn a FakeServer to make requests against the
+    given resource.
+    """
+    fake_server = FakeServer(Site(resource))
+    fake_agent = FakeServerAgent(fake_server.endpoint)
+    return HTTPClient(fake_agent)

--- a/marathon_acme/tests/test_fake_marathon.py
+++ b/marathon_acme/tests/test_fake_marathon.py
@@ -2,13 +2,9 @@ import json
 
 from testtools.matchers import Equals, Is
 
-from treq.client import HTTPClient as treq_HTTPClient
-
 from twisted.internet.defer import inlineCallbacks, DeferredQueue
 from twisted.protocols.loopback import _LoopbackAddress
-from twisted.web.server import Site
 
-from txfake import FakeServer
 from txfake.fake_connection import wait0
 
 from marathon_acme.clients import (
@@ -16,7 +12,7 @@ from marathon_acme.clients import (
     sse_content_with_protocol)
 from marathon_acme.tests.fake_marathon import (
     FakeMarathon, FakeMarathonAPI, FakeMarathonLb)
-from marathon_acme.tests.helpers import FakeServerAgent, TestCase
+from marathon_acme.tests.helpers import fake_client, TestCase
 from marathon_acme.tests.matchers import (
     HasHeader, IsJsonResponseWithCode, IsMarathonEvent, IsSseResponse)
 
@@ -36,10 +32,9 @@ class TestFakeMarathonAPI(TestCase):
         # https://github.com/twisted/klein/issues/102
         _LoopbackAddress.port = 7000
 
-        fake_server = FakeServer(Site(self.marathon_api.app.resource()))
-        fake_agent = FakeServerAgent(fake_server.endpoint)
-        fake_client = treq_HTTPClient(fake_agent)
-        self.client = JsonClient('http://www.example.com', client=fake_client)
+        self.client = JsonClient(
+            'http://www.example.com',
+            client=fake_client(self.marathon_api.app.resource()))
 
     @inlineCallbacks
     def test_get_apps_empty(self):
@@ -200,10 +195,9 @@ class TestFakeMarathonLb(TestCase):
         # https://github.com/twisted/klein/issues/102
         _LoopbackAddress.port = 7000
 
-        fake_server = FakeServer(Site(self.marathon_lb.app.resource()))
-        fake_agent = FakeServerAgent(fake_server.endpoint)
-        fake_client = treq_HTTPClient(fake_agent)
-        self.client = HTTPClient('http://www.example.com', client=fake_client)
+        self.client = HTTPClient(
+            'http://www.example.com',
+            client=fake_client(self.marathon_lb.app.resource()))
 
     @inlineCallbacks
     def test_signal_hup(self):

--- a/marathon_acme/tests/test_fake_marathon.py
+++ b/marathon_acme/tests/test_fake_marathon.py
@@ -2,6 +2,8 @@ import json
 
 from testtools.matchers import Equals, Is
 
+from treq.client import HTTPClient as treq_HTTPClient
+
 from twisted.internet.defer import inlineCallbacks, DeferredQueue
 from twisted.protocols.loopback import _LoopbackAddress
 from twisted.web.server import Site
@@ -36,7 +38,8 @@ class TestFakeMarathonAPI(TestCase):
 
         fake_server = FakeServer(Site(self.marathon_api.app.resource()))
         fake_agent = FakeServerAgent(fake_server.endpoint)
-        self.client = JsonClient('http://www.example.com', agent=fake_agent)
+        fake_client = treq_HTTPClient(fake_agent)
+        self.client = JsonClient('http://www.example.com', client=fake_client)
 
     @inlineCallbacks
     def test_get_apps_empty(self):
@@ -199,7 +202,8 @@ class TestFakeMarathonLb(TestCase):
 
         fake_server = FakeServer(Site(self.marathon_lb.app.resource()))
         fake_agent = FakeServerAgent(fake_server.endpoint)
-        self.client = HTTPClient('http://www.example.com', agent=fake_agent)
+        fake_client = treq_HTTPClient(fake_agent)
+        self.client = HTTPClient('http://www.example.com', client=fake_client)
 
     @inlineCallbacks
     def test_signal_hup(self):

--- a/marathon_acme/tests/test_server.py
+++ b/marathon_acme/tests/test_server.py
@@ -5,6 +5,8 @@ from twisted.web.server import Site
 
 from testtools.matchers import Equals
 
+from treq.client import HTTPClient as treq_HTTPClient
+
 from txfake import FakeServer
 
 from marathon_acme.clients import JsonClient, json_content
@@ -27,7 +29,8 @@ class TestHealthServer(TestCase):
 
         fake_server = FakeServer(Site(self.event_server.app.resource()))
         fake_agent = FakeServerAgent(fake_server.endpoint)
-        self.client = JsonClient('http://www.example.com', agent=fake_agent)
+        fake_client = treq_HTTPClient(fake_agent)
+        self.client = JsonClient('http://www.example.com', client=fake_client)
 
     @inlineCallbacks
     def test_health_healthy(self):

--- a/marathon_acme/tests/test_server.py
+++ b/marathon_acme/tests/test_server.py
@@ -1,17 +1,12 @@
 # -*- coding: utf-8 -*-
 from twisted.internet.defer import inlineCallbacks
 from twisted.protocols.loopback import _LoopbackAddress
-from twisted.web.server import Site
 
 from testtools.matchers import Equals
 
-from treq.client import HTTPClient as treq_HTTPClient
-
-from txfake import FakeServer
-
 from marathon_acme.clients import JsonClient, json_content
 from marathon_acme.server import HealthServer, Health
-from marathon_acme.tests.helpers import TestCase, FakeServerAgent
+from marathon_acme.tests.helpers import fake_client, TestCase
 from marathon_acme.tests.matchers import IsJsonResponseWithCode
 
 
@@ -27,10 +22,9 @@ class TestHealthServer(TestCase):
         # https://github.com/twisted/klein/issues/102
         _LoopbackAddress.port = 7000
 
-        fake_server = FakeServer(Site(self.event_server.app.resource()))
-        fake_agent = FakeServerAgent(fake_server.endpoint)
-        fake_client = treq_HTTPClient(fake_agent)
-        self.client = JsonClient('http://www.example.com', client=fake_client)
+        self.client = JsonClient(
+            'http://www.example.com',
+            client=fake_client(self.event_server.app.resource()))
 
     @inlineCallbacks
     def test_health_healthy(self):


### PR DESCRIPTION
So we can use `treq.testing.StubTreq`