### PR TITLE
Increase the maximum SSE line length to 1MiB

### DIFF
--- a/marathon_acme/sse_protocol.py
+++ b/marathon_acme/sse_protocol.py
@@ -9,7 +9,7 @@ class SseProtocol(Protocol):
     https://html.spec.whatwg.org/multipage/comms.html#server-sent-events
     """
 
-    MAX_LENGTH = 16384
+    MAX_LENGTH = 1024 * 1024 * 1024  # 1MiB
     log = Logger()
 
     def __init__(self, handler):

--- a/marathon_acme/tests/test_sse_protocol.py
+++ b/marathon_acme/tests/test_sse_protocol.py
@@ -199,6 +199,7 @@ class TestSseProtocol(object):
         the transport should be in 'disconnecting' state due to a request to
         lose the connection.
         """
+        self.protocol.MAX_LENGTH = 8  # Very long bytearrays slow down tests
         self.protocol.dataReceived(b'data:%s\r\n\r\n' % (
             b'x' * (self.protocol.MAX_LENGTH + 1),))
 
@@ -210,6 +211,7 @@ class TestSseProtocol(object):
         length, the transport should be in 'disconnecting' state due to a
         request to lose the connection.
         """
+        self.protocol.MAX_LENGTH = 8  # Very long bytearrays slow down tests
         self.protocol.dataReceived(b'data:%s' % (
             b'x' * (self.protocol.MAX_LENGTH + 1),))
 


### PR DESCRIPTION
Currently seeing ~20KiB lines in QA. If production has ~7x more apps that means possibly ~150KiB lines. Just set a big limit for now to avoid problems.