### PR TITLE
Allow specifying multiple Marathon addresses and failover to each sequentially

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The ACME provider that most people are likely to use is [Let's Encrypt](https://
 
 ```
 > $ docker run --rm praekeltfoundation/marathon-acme:develop marathon-acme --help
-usage: marathon-acme [-h] [-a ACME] [-m MARATHON] [-l LB [LB ...]] [-g GROUP]
-                     [--listen LISTEN]
+usage: marathon-acme [-h] [-a ACME] [-m MARATHON [MARATHON ...]]
+                     [-l LB [LB ...]] [-g GROUP] [--listen LISTEN]
                      [--log-level {debug,info,warn,error,critical}]
                      storage-dir
 
@@ -37,7 +37,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -a ACME, --acme ACME  The address for the ACME Directory Resource (default:
                         https://acme-v01.api.letsencrypt.org/directory)
-  -m MARATHON, --marathon MARATHON
+  -m MARATHON [MARATHON ...], --marathon MARATHON [MARATHON ...]
                         The address for the Marathon HTTP API (default:
                         http://marathon.mesos:8080)
   -l LB [LB ...], --lb LB [LB ...]
@@ -119,15 +119,15 @@ The `marathon-acme` Docker container can be configured either using command-line
 
 The environment variables available correspond to the CLI options as follows:
 
-| Environment variable      | CLI option    |
-|---------------------------|---------------|
-| `MARATHON_ACME_ACME`      | `--acme`      |
-| `MARATHON_ACME_MARATHON`  | `--marathon`  |
-| `MARATHON_ACME_LBS`*      | `--lb`        |
-| `MARATHON_ACME_GROUP`     | `--group`     |
-| `MARATHON_ACME_LOG_LEVEL` | `--log-level` |
+| Environment variable       | CLI option    |
+|----------------------------|---------------|
+| `MARATHON_ACME_ACME`       | `--acme`      |
+| `MARATHON_ACME_MARATHONS`* | `--marathon`  |
+| `MARATHON_ACME_LBS`*       | `--lb`        |
+| `MARATHON_ACME_GROUP`      | `--group`     |
+| `MARATHON_ACME_LOG_LEVEL`  | `--log-level` |
 
-\*Multiple load balancers can be set using multiple spaces-separated addresses.
+\*Multiple addresses should be space-separated.
 
 #### Volumes and ports
 The `marathon-acme` container defaults to the `/var/lib/marathon-acme` directory to store certificates and the ACME client private key. This is the path inside the container that should be mounted as a shared volume.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Options can be set using environment variables:
 # MARATHON_ACME_ACME:      --acme
-# MARATHON_ACME_MARATHON:  --marathon
+# MARATHON_ACME_MARATHONS:  --marathon
 # MARATHON_ACME_LBS:       --lb
 # MARATHON_ACME_GROUP:     --group
 # MARATHON_ACME_LOG_LEVEL: --log-level
@@ -13,7 +13,7 @@
 
 exec marathon-acme \
   ${MARATHON_ACME_ACME:+--acme "$MARATHON_ACME_ACME"} \
-  ${MARATHON_ACME_MARATHON:+--marathon "$MARATHON_ACME_MARATHON"} \
+  ${MARATHON_ACME_MARATHONS:+--marathon $MARATHON_ACME_MARATHONS} \
   ${MARATHON_ACME_LBS:+--lb $MARATHON_ACME_LBS} \
   ${MARATHON_ACME_GROUP:+--group "$MARATHON_ACME_GROUP"} \
   ${MARATHON_ACME_LOG_LEVEL:+--log-level "$MARATHON_ACME_LOG_LEVEL"} \

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -22,7 +22,7 @@ parser.add_argument('-a', '--acme',
                          '(default: %(default)s)',
                     default=(
                         'https://acme-v01.api.letsencrypt.org/directory'))
-parser.add_argument('-m', '--marathon',
+parser.add_argument('-m', '--marathon', nargs='+',
                     help='The address for the Marathon HTTP API (default: '
                          '%(default)s)',
                     default='http://marathon.mesos:8080')
@@ -69,7 +69,7 @@ def main(reactor, raw_args=sys.argv[1:]):
 
 
 def create_marathon_acme(storage_dir, acme_directory,
-                         marathon_addr, mlb_addrs, group,
+                         marathon_addrs, mlb_addrs, group,
                          reactor):
     """
     Create a marathon-acme instance.
@@ -93,7 +93,7 @@ def create_marathon_acme(storage_dir, acme_directory,
     key = maybe_key(storage_path)
 
     return MarathonAcme(
-        MarathonClient(marathon_addr, reactor=reactor),
+        MarathonClient(marathon_addrs, reactor=reactor),
         group,
         DirectoryStore(certs_path),
         MarathonLbClient(mlb_addrs, reactor=reactor),

--- a/marathon_acme/clients.py
+++ b/marathon_acme/clients.py
@@ -270,7 +270,9 @@ class MarathonClient(JsonClient):
         self.endpoints = endpoints
 
     def request(self, *args, **kwargs):
-        return self._request(None, list(self.endpoints), *args, **kwargs)
+        d = self._request(None, list(self.endpoints), *args, **kwargs)
+        d.addErrback(self._log_all_endpoints_failed)
+        return d
 
     def _request(self, failure, endpoints, *args, **kwargs):
         """
@@ -287,6 +289,13 @@ class MarathonClient(JsonClient):
         # endpoints
         d.addErrback(self._request, endpoints, *args, **kwargs)
         return d
+
+    def _log_all_endpoints_failed(self, failure):
+        # Just log an error so it is clear what has happened and return the
+        # final failure. Individual failures should have been logged via
+        # _log_request_error().
+        self.log.error('Failed to make a request to all Marathon endpoints')
+        return failure
 
     def get_json_field(self, field, **kwargs):
         """

--- a/marathon_acme/tests/helpers.py
+++ b/marathon_acme/tests/helpers.py
@@ -1,12 +1,39 @@
 from treq.client import HTTPClient
 from twisted.internet.defer import fail
+from uritools import urisplit
 
 
 class FailingAgent(object):
+    def __init__(self, error=RuntimeError()):
+        self.error = error
+
     """ A twisted.web.iweb.IAgent that does nothing but fail. """
     def request(self, method, uri, headers=None, bodyProducer=None):
-        return fail(RuntimeError())
+        return fail(self.error)
 
 
 """ A Treq client that will fail with a RuntimeError for any request made. """
 failing_client = HTTPClient(FailingAgent())
+
+
+class PerLocationAgent(object):
+    """
+    A twisted.web.iweb.IAgent that delegates to other agents for specific URI
+    locations.
+    """
+    def __init__(self):
+        self.agents = {}
+
+    def add_agent(self, location, agent):
+        """
+        Add an agent for URIs with the specified location.
+        :param bytes location:
+            The URI authority/location (e.g. b'example.com:80')
+        :param agent: The twisted.web.iweb.IAgent to use for the location
+        """
+        self.agents[location] = agent
+
+    def request(self, method, uri, headers=None, bodyProducer=None):
+        agent = self.agents[urisplit(uri).authority]
+        return agent.request(
+            method, uri, headers=headers, bodyProducer=bodyProducer)

--- a/marathon_acme/tests/test_clients.py
+++ b/marathon_acme/tests/test_clients.py
@@ -522,6 +522,9 @@ class TestMarathonClient(TestHTTPClientBase):
     def get_client(self, client):
         return MarathonClient(['http://localhost:8080'], client=client)
 
+    def uri(self, path, index=0):
+        return ''.join((self.client.endpoints[index], path))
+
     @inlineCallbacks
     def test_request_success(self):
         """
@@ -606,7 +609,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
-            method='GET', url='http://localhost:8080/my-path'))
+            method='GET', url=self.uri('/my-path')))
 
         json_response(request, {
             'field-key': 'field-value',
@@ -627,7 +630,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
-            method='GET', url='http://localhost:8080/my-path'))
+            method='GET', url=self.uri('/my-path')))
 
         request.setResponseCode(404)
         request.write(b'Not found\n')
@@ -635,8 +638,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         yield wait0()
         self.assertThat(d, failed(WithErrorTypeAndMessage(
-            HTTPError,
-            '404 Client Error for url: http://localhost:8080/my-path')))
+            HTTPError, '404 Client Error for url: %s' % self.uri('/my-path'))))
 
     @inlineCallbacks
     def test_get_json_field_missing(self):
@@ -650,7 +652,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
-            method='GET', url='http://localhost:8080/my-path'))
+            method='GET', url=self.uri('/my-path')))
 
         json_response(request, {'other-field-key': 'do-not-care'})
 
@@ -671,7 +673,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
-            method='GET', url='http://localhost:8080/v2/apps'))
+            method='GET', url=self.uri('/v2/apps')))
 
         apps = {
             'apps': [
@@ -723,7 +725,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
-            method='GET', url='http://localhost:8080/v2/events'))
+            method='GET', url=self.uri('/v2/events')))
         self.assertThat(request.requestHeaders,
                         HasHeader('accept', ['text/event-stream']))
 
@@ -756,7 +758,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
-            method='GET', url='http://localhost:8080/v2/events'))
+            method='GET', url=self.uri('/v2/events')))
         self.assertThat(request.requestHeaders,
                         HasHeader('accept', ['text/event-stream']))
 
@@ -798,7 +800,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
-            method='GET', url='http://localhost:8080/v2/events'))
+            method='GET', url=self.uri('/v2/events')))
         self.assertThat(request.requestHeaders,
                         HasHeader('accept', ['text/event-stream']))
 
@@ -836,7 +838,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
-            method='GET', url='http://localhost:8080/v2/events'))
+            method='GET', url=self.uri('/v2/events')))
         self.assertThat(request.requestHeaders,
                         HasHeader('accept', ['text/event-stream']))
 
@@ -870,7 +872,7 @@ class TestMarathonClient(TestHTTPClientBase):
 
         request = yield self.requests.get()
         self.assertThat(request, HasRequestProperties(
-            method='GET', url='http://localhost:8080/v2/events'))
+            method='GET', url=self.uri('/v2/events')))
         self.assertThat(request.requestHeaders,
                         HasHeader('accept', ['text/event-stream']))
 

--- a/marathon_acme/tests/test_service.py
+++ b/marathon_acme/tests/test_service.py
@@ -92,7 +92,7 @@ class TestMarathonAcme(object):
         self.fake_marathon = FakeMarathon()
         self.fake_marathon_api = FakeMarathonAPI(self.fake_marathon)
         marathon_client = MarathonClient(
-            'http://localhost:8080', client=self.fake_marathon_api.client)
+            ['http://localhost:8080'], client=self.fake_marathon_api.client)
 
         self.cert_store = MemoryStore()
 

--- a/marathon_acme/tests/test_service.py
+++ b/marathon_acme/tests/test_service.py
@@ -154,7 +154,7 @@ class TestMarathonAcme(object):
 
         # Some other client attaches
         other_client = MarathonClient(
-            'http://localhost:8080', client=self.fake_marathon_api.client)
+            ['http://localhost:8080'], client=self.fake_marathon_api.client)
         other_client_events = []
         other_client.get_events(
             {'event_stream_attached': other_client_events.append})

--- a/marathon_acme/tests/test_test_helpers.py
+++ b/marathon_acme/tests/test_test_helpers.py
@@ -1,0 +1,81 @@
+import pytest
+from testtools import ExpectedException
+from testtools.assertions import assert_that
+from testtools.matchers import (
+    Equals, Is, IsInstance, MatchesAll, MatchesDict, MatchesListwise,
+    MatchesPredicate, MatchesStructure)
+from testtools.twistedsupport import failed, succeeded
+from twisted.internet.defer import succeed
+
+from marathon_acme.tests.helpers import FailingAgent, PerLocationAgent
+
+
+class DummyAgent(object):
+    def request(self, *args, **kwargs):
+        return succeed((args, kwargs))
+
+
+class TestPerLocationAgent(object):
+    @pytest.fixture
+    def agent(self):
+        return PerLocationAgent()
+
+    def test_keyerror_if_location_unset(self, agent):
+        """
+        When a request is made using the agent and no delegate agent has been
+        added for the URI location/authority, a KeyError is expected.
+        """
+        with ExpectedException(KeyError, "b'foo:8080'"):
+            agent.request(b'GET', b'http://foo:8080')
+
+    def test_delegates_to_agent_for_location(self, agent):
+        """
+        When a request is made using the agent, the added agents are delegated
+        to based on the URI location/authority.
+        """
+        agent.add_agent(b'foo:8080', DummyAgent())
+        agent.add_agent(b'bar:8080', FailingAgent(RuntimeError('bar')))
+        agent.add_agent(b'foo:9090', FailingAgent(RuntimeError('9090')))
+
+        d = agent.request(b'GET', b'http://foo:8080')
+        assert_that(d, succeeded(MatchesListwise([
+            MatchesListwise([Equals(b'GET'), Equals(b'http://foo:8080')]),
+            MatchesDict({'headers': Is(None), 'bodyProducer': Is(None)})
+        ])))
+
+        # Scheme doesn't matter
+        d = agent.request(b'GET', b'https://foo:8080')
+        assert_that(d, succeeded(MatchesListwise([
+            MatchesListwise([Equals(b'GET'), Equals(b'https://foo:8080')]),
+            MatchesDict({'headers': Is(None), 'bodyProducer': Is(None)})
+        ])))
+
+        # Path doesn't matter
+        d = agent.request(b'GET', b'http://foo:8080/bar/baz')
+        assert_that(d, succeeded(MatchesListwise([
+            MatchesListwise([
+                Equals(b'GET'), Equals(b'http://foo:8080/bar/baz')]),
+            MatchesDict({'headers': Is(None), 'bodyProducer': Is(None)})
+        ])))
+
+        # Hostname *does* matter
+        d = agent.request(b'GET', b'http://bar:8080')
+        assert_that(d, failed(MatchesStructure(value=MatchesAll(
+            IsInstance(RuntimeError),
+            MatchesPredicate(str, Equals('bar'))
+        ))))
+
+        # Port *does* matter
+        d = agent.request(b'GET', b'http://foo:9090')
+        assert_that(d, failed(MatchesStructure(value=MatchesAll(
+            IsInstance(RuntimeError),
+            MatchesPredicate(str, Equals('9090'))
+        ))))
+
+        # Other args passed through
+        d = agent.request(b'GET', b'http://foo:8080', 'bar', 'baz')
+        assert_that(d, succeeded(MatchesListwise([
+            MatchesListwise([Equals(b'GET'), Equals(b'http://foo:8080')]),
+            MatchesDict(
+                {'headers': Equals('bar'), 'bodyProducer': Equals('baz')})
+        ])))

--- a/marathon_acme/tests/test_test_helpers.py
+++ b/marathon_acme/tests/test_test_helpers.py
@@ -25,7 +25,7 @@ class TestPerLocationAgent(object):
         When a request is made using the agent and no delegate agent has been
         added for the URI location/authority, a KeyError is expected.
         """
-        with ExpectedException(KeyError, "b'foo:8080'"):
+        with ExpectedException(KeyError, r"b?'foo:8080'"):
             agent.request(b'GET', b'http://foo:8080')
 
     def test_delegates_to_agent_for_location(self, agent):


### PR DESCRIPTION
Fixes #48.

I basically copied what the "official" Marathon Python client [does](https://github.com/thefactory/marathon-python/blob/0.8.7/marathon/client.py#L72-L84) but in async.