### PR TITLE
Travis: test with PyPy2 5.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
     - python: '2.7'
     - python: '3.5'
     - python: pypy
-      env: PYENV_VERSION=pypy-5.4.1 PYENV_VERSION_STRING='PyPy 5.4.1' NO_COVERAGE=1
+      env: PYENV_VERSION=pypy-5.6.0 PYENV_VERSION_STRING='PyPy 5.6.0' NO_COVERAGE=1
 cache:
   - pip
   - directories:


### PR DESCRIPTION
The real reason for this is to bump `develop` so as to build a new Docker image with upstream txacme fixes...