### PR TITLE
Use comma-separated values on the CLI for Marathon & marathon-lb addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The ACME provider that most people are likely to use is [Let's Encrypt](https://
 
 ```
 > $ docker run --rm praekeltfoundation/marathon-acme:develop marathon-acme --help
-usage: marathon-acme [-h] [-a ACME] [-m MARATHON] [-l LB] [-g GROUP]
-                     [--listen LISTEN]
+usage: marathon-acme [-h] [-a ACME] [-m MARATHON[,MARATHON,...]]
+                     [-l LB[,LB,...]] [-g GROUP] [--listen LISTEN]
                      [--log-level {debug,info,warn,error,critical}]
                      storage-dir
 
@@ -37,12 +37,12 @@ optional arguments:
   -h, --help            show this help message and exit
   -a ACME, --acme ACME  The address for the ACME Directory Resource (default:
                         https://acme-v01.api.letsencrypt.org/directory)
-  -m MARATHON, --marathon MARATHON
-                        The addresses for the Marathon HTTP API (comma-
-                        separated) (default: http://marathon.mesos:8080)
-  -l LB, --lb LB        The addresses for the marathon-lb HTTP API (comma-
-                        separated) (default: http://marathon-
-                        lb.marathon.mesos:9090)
+  -m MARATHON[,MARATHON,...], --marathon MARATHON[,MARATHON,...]
+                        The addresses for the Marathon HTTP API (default:
+                        http://marathon.mesos:8080)
+  -l LB[,LB,...], --lb LB[,LB,...]
+                        The addresses for the marathon-lb HTTP API (default:
+                        http://marathon-lb.marathon.mesos:9090)
   -g GROUP, --group GROUP
                         The marathon-lb group to issue certificates for
                         (default: external)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The ACME provider that most people are likely to use is [Let's Encrypt](https://
 
 ```
 > $ docker run --rm praekeltfoundation/marathon-acme:develop marathon-acme --help
-usage: marathon-acme [-h] [-a ACME] [-m MARATHON [MARATHON ...]]
-                     [-l LB [LB ...]] [-g GROUP] [--listen LISTEN]
+usage: marathon-acme [-h] [-a ACME] [-m MARATHON] [-l LB] [-g GROUP]
+                     [--listen LISTEN]
                      [--log-level {debug,info,warn,error,critical}]
                      storage-dir
 
@@ -37,12 +37,12 @@ optional arguments:
   -h, --help            show this help message and exit
   -a ACME, --acme ACME  The address for the ACME Directory Resource (default:
                         https://acme-v01.api.letsencrypt.org/directory)
-  -m MARATHON [MARATHON ...], --marathon MARATHON [MARATHON ...]
-                        The address for the Marathon HTTP API (default:
-                        http://marathon.mesos:8080)
-  -l LB [LB ...], --lb LB [LB ...]
-                        The address for the marathon-lb HTTP API (default:
-                        http://marathon-lb.marathon.mesos:9090)
+  -m MARATHON, --marathon MARATHON
+                        The addresses for the Marathon HTTP API (comma-
+                        separated) (default: http://marathon.mesos:8080)
+  -l LB, --lb LB        The addresses for the marathon-lb HTTP API (comma-
+                        separated) (default: http://marathon-
+                        lb.marathon.mesos:9090)
   -g GROUP, --group GROUP
                         The marathon-lb group to issue certificates for
                         (default: external)
@@ -119,15 +119,13 @@ The `marathon-acme` Docker container can be configured either using command-line
 
 The environment variables available correspond to the CLI options as follows:
 
-| Environment variable       | CLI option    |
-|----------------------------|---------------|
-| `MARATHON_ACME_ACME`       | `--acme`      |
-| `MARATHON_ACME_MARATHONS`* | `--marathon`  |
-| `MARATHON_ACME_LBS`*       | `--lb`        |
-| `MARATHON_ACME_GROUP`      | `--group`     |
-| `MARATHON_ACME_LOG_LEVEL`  | `--log-level` |
-
-\*Multiple addresses should be space-separated.
+| Environment variable      | CLI option    |
+|---------------------------|---------------|
+| `MARATHON_ACME_ACME`      | `--acme`      |
+| `MARATHON_ACME_MARATHON`  | `--marathon`  |
+| `MARATHON_ACME_LB`        | `--lb`        |
+| `MARATHON_ACME_GROUP`     | `--group`     |
+| `MARATHON_ACME_LOG_LEVEL` | `--log-level` |
 
 #### Volumes and ports
 The `marathon-acme` container defaults to the `/var/lib/marathon-acme` directory to store certificates and the ACME client private key. This is the path inside the container that should be mounted as a shared volume.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,8 +2,8 @@
 
 # Options can be set using environment variables:
 # MARATHON_ACME_ACME:      --acme
-# MARATHON_ACME_MARATHONS:  --marathon
-# MARATHON_ACME_LBS:       --lb
+# MARATHON_ACME_MARATHON:  --marathon
+# MARATHON_ACME_LB:        --lb
 # MARATHON_ACME_GROUP:     --group
 # MARATHON_ACME_LOG_LEVEL: --log-level
 
@@ -13,8 +13,8 @@
 
 exec marathon-acme \
   ${MARATHON_ACME_ACME:+--acme "$MARATHON_ACME_ACME"} \
-  ${MARATHON_ACME_MARATHONS:+--marathon $MARATHON_ACME_MARATHONS} \
-  ${MARATHON_ACME_LBS:+--lb $MARATHON_ACME_LBS} \
+  ${MARATHON_ACME_MARATHON:+--marathon "$MARATHON_ACME_MARATHON"} \
+  ${MARATHON_ACME_LB:+--lb "$MARATHON_ACME_LB"} \
   ${MARATHON_ACME_GROUP:+--group "$MARATHON_ACME_GROUP"} \
   ${MARATHON_ACME_LOG_LEVEL:+--log-level "$MARATHON_ACME_LOG_LEVEL"} \
   --listen 0.0.0.0:8000 \

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -24,13 +24,13 @@ parser.add_argument('-a', '--acme',
                          '(default: %(default)s)',
                     default=(
                         'https://acme-v01.api.letsencrypt.org/directory'))
-parser.add_argument('-m', '--marathon',
-                    help='The addresses for the Marathon HTTP API (comma-'
-                         'separated) (default: %(default)s)',
+parser.add_argument('-m', '--marathon', metavar='MARATHON[,MARATHON,...]',
+                    help='The addresses for the Marathon HTTP API (default: '
+                         '%(default)s)',
                     default='http://marathon.mesos:8080')
-parser.add_argument('-l', '--lb',
-                    help='The addresses for the marathon-lb HTTP API (comma-'
-                         'separated) (default: %(default)s)',
+parser.add_argument('-l', '--lb', metavar='LB[,LB,...]',
+                    help='The addresses for the marathon-lb HTTP API '
+                         '(default: %(default)s)',
                     default='http://marathon-lb.marathon.mesos:9090')
 parser.add_argument('-g', '--group',
                     help='The marathon-lb group to issue certificates for '


### PR DESCRIPTION
* Log the options that marathon-acme was started with.