### PR TITLE
Support pre-1.0.0 Marathon by using the 'ports' field

### DIFF
--- a/marathon_acme/service.py
+++ b/marathon_acme/service.py
@@ -166,12 +166,12 @@ class MarathonAcme(object):
         # Prefer the 'portDefinitions' field added in Marathon 1.0.0 but fall
         # back to the deprecated 'ports' array if that's not present.
         if 'portDefinitions' in app:
-            ports = app['portDefinitions']
+            num_ports = len(app['portDefinitions'])
         else:
-            ports = app['ports']
+            num_ports = len(app['ports'])
 
         # Iterate through the ports, checking for corresponding labels
-        for port_index, _ in enumerate(ports):
+        for port_index in range(num_ports):
             # Get the port group label, defaulting to the app group label
             port_group = labels.get(
                 'HAPROXY_%d_GROUP' % (port_index,), app_group)

--- a/marathon_acme/service.py
+++ b/marathon_acme/service.py
@@ -166,12 +166,12 @@ class MarathonAcme(object):
         # Prefer the 'portDefinitions' field added in Marathon 1.0.0 but fall
         # back to the deprecated 'ports' array if that's not present.
         if 'portDefinitions' in app:
-            num_ports = len(app['portDefinitions'])
+            ports = app['portDefinitions']
         else:
-            num_ports = len(app['ports'])
+            ports = app['ports']
 
         # Iterate through the ports, checking for corresponding labels
-        for port_index in range(num_ports):
+        for port_index, _ in enumerate(ports):
             # Get the port group label, defaulting to the app group label
             port_group = labels.get(
                 'HAPROXY_%d_GROUP' % (port_index,), app_group)

--- a/marathon_acme/service.py
+++ b/marathon_acme/service.py
@@ -163,8 +163,15 @@ class MarathonAcme(object):
         labels = app['labels']
         app_group = labels.get('HAPROXY_GROUP')
 
+        # Prefer the 'portDefinitions' field added in Marathon 1.0.0 but fall
+        # back to the deprecated 'ports' array if that's not present.
+        if 'portDefinitions' in app:
+            ports = app['portDefinitions']
+        else:
+            ports = app['ports']
+
         # Iterate through the ports, checking for corresponding labels
-        for port_index, _ in enumerate(app['portDefinitions']):
+        for port_index, _ in enumerate(ports):
             # Get the port group label, defaulting to the app group label
             port_group = labels.get(
                 'HAPROXY_%d_GROUP' % (port_index,), app_group)

--- a/marathon_acme/tests/test_service.py
+++ b/marathon_acme/tests/test_service.py
@@ -320,8 +320,7 @@ class TestMarathonAcme(object):
             'portDefinitions': [
                 {'port': 9000, 'protocol': 'tcp', 'labels': {}},
                 {'port': 9001, 'protocol': 'tcp', 'labels': {}}
-            ],
-            'ports': [10007]
+            ]
         })
 
         d = self.marathon_acme.sync()
@@ -351,6 +350,40 @@ class TestMarathonAcme(object):
                 'MARATHON_ACME_0_DOMAIN': 'example.com'
             },
             'ports': [10007]  # Some random service port
+        })
+
+        d = self.marathon_acme.sync()
+        assert_that(d, succeeded(MatchesListwise([  # Per domain
+            is_marathon_lb_sigusr_response
+        ])))
+
+        assert_that(self.cert_store.as_dict(), succeeded(MatchesDict({
+            'example.com': Not(Is(None))
+        })))
+
+        assert_that(self.fake_marathon_lb.check_signalled_usr1(), Equals(True))
+
+    def test_sync_app_port_definitions_preferred(self):
+        """
+        When a sync is run and this Marathon returns both the
+        'portDefinitions' field and 'ports' field with the app definitions,
+        the 'portsDefinition' field should be used and 'ports' ignored.
+        """
+        # Store an app in Marathon with a marathon-acme domain
+        self.fake_marathon.add_app({
+            'id': '/my-app_1',
+            'labels': {
+                'HAPROXY_GROUP': 'external',
+                'MARATHON_ACME_0_DOMAIN': 'example.com'
+            },
+            'portDefinitions': [
+                {'port': 9000, 'protocol': 'tcp', 'labels': {}},
+                {'port': 9001, 'protocol': 'tcp', 'labels': {}}
+            ],
+            # There should never be a different number of elements in
+            # 'portDefinitions' and 'ports' but 'ports' is deprecated and we
+            # want to make sure it is ignored if 'portDefinitions' is present
+            'ports': []
         })
 
         d = self.marathon_acme.sync()


### PR DESCRIPTION
Fixes #81 
* 'portsDefinition' not present in older versions