### PR TITLE
Parse CLI listen address into a Twisted endpoint description

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ optional arguments:
   -g GROUP, --group GROUP
                         The marathon-lb group to issue certificates for
                         (default: external)
-  --listen LISTEN       The address for the port to listen on (default:
-                        0.0.0.0:8000)
+  --listen LISTEN       The address for the port to listen on (default: :8000)
   --log-level {debug,info,warn,error,critical}
                         The minimum severity level to log messages at
                         (default: info)

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -43,7 +43,7 @@ parser.add_argument('-g', '--group',
 parser.add_argument('--listen',
                     help='The address for the port to listen on (default: '
                          '%(default)s)',
-                    default='0.0.0.0:8000')
+                    default=':8000')
 parser.add_argument('--log-level',
                     help='The minimum severity level to log messages at '
                          '(default: %(default)s)',

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -2,6 +2,7 @@ import argparse
 import ipaddress
 import sys
 
+from twisted.internet.endpoints import quoteStringArgument
 from twisted.internet.task import react
 from twisted.logger import (
     FilteringLogObserver, globalLogPublisher, Logger, LogLevel,
@@ -129,7 +130,8 @@ def parse_listen_addr(listen_addr):
 
 
 def _create_tx_endpoints_string(args, kwargs):
-    _kwargs = ['='.join((k, v.replace(':', '\:'))) for k, v in kwargs.items()]
+    _kwargs = (
+        ['='.join((k, quoteStringArgument(v))) for k, v in kwargs.items()])
     return ':'.join(args + _kwargs)
 
 

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -6,7 +6,7 @@ from twisted.internet.task import react
 from twisted.logger import (
     FilteringLogObserver, globalLogPublisher, Logger, LogLevel,
     LogLevelFilterPredicate, textFileLogObserver)
-from twisted.python.compat import _PY3
+from twisted.python.compat import unicode
 from twisted.python.filepath import FilePath
 from twisted.python.url import URL
 from txacme.store import DirectoryStore
@@ -88,7 +88,10 @@ def main(reactor, raw_args=sys.argv[1:]):
 
 
 def _to_unicode(string):
-    return unicode(string) if not _PY3 else string
+    if isinstance(string, unicode):
+        return string
+    elif isinstance(string, bytes):
+        return unicode(string, 'utf-8')
 
 
 def parse_listen_addr(listen_addr):

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -6,6 +6,7 @@ from twisted.internet.task import react
 from twisted.logger import (
     FilteringLogObserver, globalLogPublisher, Logger, LogLevel,
     LogLevelFilterPredicate, textFileLogObserver)
+from twisted.python.compat import _PY3
 from twisted.python.filepath import FilePath
 from twisted.python.url import URL
 from txacme.store import DirectoryStore
@@ -86,6 +87,10 @@ def main(reactor, raw_args=sys.argv[1:]):
     return marathon_acme.run(endpoint_description)
 
 
+def _to_unicode(string):
+    return unicode(string) if not _PY3 else string
+
+
 def parse_listen_addr(listen_addr):
     """
     Parse an address of the form [ipaddress]:port into a tcp or tcp6 Twisted
@@ -105,7 +110,7 @@ def parse_listen_addr(listen_addr):
     else:
         if host.startswith('[') and host.endswith(']'):  # IPv6 wrapped in []
             host = host[1:-1]
-        ip_address = ipaddress.ip_address(host)
+        ip_address = ipaddress.ip_address(_to_unicode(host))
         protocol = 'tcp6' if ip_address.version == 6 else 'tcp'
         interface = str(ip_address)
 
@@ -148,7 +153,7 @@ def create_marathon_acme(storage_dir, acme_directory, acme_email,
     :param reactor: The reactor to use.
     """
     storage_path, certs_path = init_storage_dir(storage_dir)
-    acme_url = URL.fromText(acme_directory)
+    acme_url = URL.fromText(_to_unicode(acme_directory))
     key = maybe_key(storage_path)
 
     return MarathonAcme(

--- a/marathon_acme/server.py
+++ b/marathon_acme/server.py
@@ -1,6 +1,7 @@
 import json
 
 from klein import Klein
+from twisted.internet.endpoints import serverFromString
 from twisted.logger import Logger
 from twisted.web.http import OK, NOT_IMPLEMENTED, SERVICE_UNAVAILABLE
 from twisted.web.server import Site
@@ -25,18 +26,19 @@ class MarathonAcmeServer(object):
         self.responder_resource = responder_resource
         self.health_handler = None
 
-    def listen(self, host, port, reactor):
+    def listen(self, reactor, endpoint_description):
         """
         Run the server, i.e. start listening for requests on the given host and
         port.
 
-        :param host: The address for the interface to listen on.
-        :param port: The port to bind to.
         :param reactor: The ``IReactorTCP`` to use.
-        :return: An object that provides ``IListeningPort``.
+        :param endpoint_description:
+            The Twisted description for the endpoint to listen on.
+        :return:
+            A deferred that returns an object that provides ``IListeningPort``.
         """
-        site = Site(self.app.resource())
-        return reactor.listenTCP(port, site, interface=host)
+        endpoint = serverFromString(reactor, endpoint_description)
+        return endpoint.listen(Site(self.app.resource()))
 
     @app.route('/.well-known/acme-challenge/', branch=True, methods=['GET'])
     def acme_challenge(self, request):

--- a/marathon_acme/tests/test_cli.py
+++ b/marathon_acme/tests/test_cli.py
@@ -121,9 +121,9 @@ class TestParseListenAddr(object):
         is raised.
         """
         with ExpectedException(
-                ValueError,
-                r"'localhost' does not appear to be an IPv4 or IPv6 address"):
-            parse_listen_addr('localhost:8080')
+            ValueError,
+                r"u?'hello' does not appear to be an IPv4 or IPv6 address"):
+            parse_listen_addr('hello:8080')
 
     def test_parse_invalid_port(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,19 @@
+import sys
+
 from setuptools import setup, find_packages
 
+install_requires = [
+    'acme',
+    'cryptography',
+    'klein==15.3.1',
+    'requests',
+    'treq',
+    'Twisted',
+    'txacme',
+    'uritools>=1.0.0'
+]
+if sys.version_info < (3, 3):
+    install_requires.append('ipaddress')
 
 setup(
     name='marathon-acme',
@@ -11,17 +25,7 @@ setup(
     author='Jamie Hewland',
     author_email='jamie@praekelt.com',
     packages=find_packages(),
-    install_requires=[
-        'acme',
-        'cryptography',
-        "ipaddress; python_version < '3.3'",
-        'klein==15.3.1',
-        'requests',
-        'treq',
-        'Twisted',
-        'txacme',
-        'uritools>=1.0.0'
-    ],
+    install_requires=install_requires,
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Framework :: Twisted',

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     install_requires=[
         'acme',
         'cryptography',
+        "ipaddress; python_version < '3.3'",
         'klein==15.3.1',
         'requests',
         'treq',


### PR DESCRIPTION
* Support IPv6 endpoints
* Support listen addresses without a specific interface address
* Much better validation
* Pass endpoint descriptions around
* Test the case that we can't listen on a port