### PR TITLE
treq's json_content now uses the correct encoding

### DIFF
--- a/marathon_acme/clients.py
+++ b/marathon_acme/clients.py
@@ -3,6 +3,7 @@ import json
 
 from requests.exceptions import HTTPError
 from treq.client import HTTPClient as treq_HTTPClient
+from treq.content import json_content
 from twisted.internet.defer import DeferredList
 from twisted.logger import Logger, LogLevel
 from twisted.web.http import OK
@@ -27,17 +28,6 @@ def get_single_header(headers, key):
     # Take the final header as the authorative
     header, _ = cgi.parse_header(raw_headers[-1])
     return header
-
-
-def json_content(response):
-    # Raise if content type is not application/json
-    raise_for_header(response, 'Content-Type', 'application/json')
-
-    # Workaround for treq not treating JSON as UTF-8 by default (RFC7158)
-    # https://github.com/twisted/treq/pull/126
-    # See this discussion: http://stackoverflow.com/q/9254891
-    d = response.text(encoding='utf-8')
-    return d.addCallback(json.loads)
 
 
 def raise_for_status(response):

--- a/marathon_acme/clients.py
+++ b/marathon_acme/clients.py
@@ -302,6 +302,7 @@ class MarathonClient(JsonClient):
         """
         d = self.request('GET', **kwargs)
         d.addCallback(raise_for_status)
+        d.addCallback(raise_for_header, 'Content-Type', 'application/json')
         d.addCallback(json_content)
         d.addCallback(self._get_json_field, field)
         return d

--- a/marathon_acme/tests/test_fake_marathon.py
+++ b/marathon_acme/tests/test_fake_marathon.py
@@ -7,9 +7,9 @@ from testtools.matchers import AfterPreprocessing as After
 from testtools.matchers import (
     Equals, Is, MatchesAll, MatchesListwise, MatchesStructure)
 from testtools.twistedsupport import succeeded
+from treq.content import json_content
 
-from marathon_acme.clients import (
-    json_content, sse_content, _sse_content_with_protocol)
+from marathon_acme.clients import sse_content, _sse_content_with_protocol
 from marathon_acme.tests.fake_marathon import (
     FakeMarathon, FakeMarathonAPI, FakeMarathonLb)
 from marathon_acme.tests.matchers import (

--- a/marathon_acme/tests/test_server.py
+++ b/marathon_acme/tests/test_server.py
@@ -5,11 +5,11 @@ from testtools.assertions import assert_that
 from testtools.matchers import AfterPreprocessing as After
 from testtools.matchers import Equals, MatchesAll, MatchesStructure
 from testtools.twistedsupport import succeeded
+from treq.content import json_content
 from treq.testing import StubTreq
 from twisted.web.resource import Resource
 from twisted.web.static import Data
 
-from marathon_acme.clients import json_content
 from marathon_acme.server import MarathonAcmeServer, Health
 from marathon_acme.tests.matchers import HasHeader, IsJsonResponseWithCode
 


### PR DESCRIPTION
twisted/treq#126