### PR TITLE
Add a ping endpoint to the acme-challenge path for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,16 @@ The library used for ACME certificate management, `txacme`, is currently quite l
 * There is no support for *removing* certificates from `txacme`'s certificate store ([#77](https://github.com/mithrandi/txacme/issues/77)). Once `marathon-acme` issues a certificate for an app it will try to renew that certificate *forever* unless it is manually deleted from the certificate store.
 
 For a more complete list of issues, see the issues page for this repo.
+
+## Troubleshooting
+### Challenge ping endpoint
+One common problem is that `marathon-lb` is misconfigured and ACME challenge requests are unable to reach `marathon-acme`. You can test challenge request routing to `marathon-acme` using the challenge ping endpoint.
+
+It should be possible to reach the  `/.well-known/acme-challenge/ping` path from all domains served by `marathon-lb`:
+```
+> $ curl cake-service.example.com/.well-known/acme-challenge/ping
+{"message": "pong"}
+
+> $ curl soda-service.example.com/.well-known/acme-challenge/ping
+{"message": "pong"}
+```

--- a/marathon_acme/server.py
+++ b/marathon_acme/server.py
@@ -48,6 +48,15 @@ class MarathonAcmeServer(object):
         """
         return self.responder_resource
 
+    @app.route('/.well-known/acme-challenge/ping', methods=['GET'])
+    def acme_challenge_ping(self, request):
+        """
+        Respond to requests on ``/.well-known/acme-challenge/ping`` to debug
+        path routing issues.
+        """
+        request.setResponseCode(OK)
+        write_request_json(request, {'message': 'pong'})
+
     def set_health_handler(self, health_handler):
         """
         Set the handler for the health endpoint.

--- a/marathon_acme/tests/test_server.py
+++ b/marathon_acme/tests/test_server.py
@@ -51,6 +51,18 @@ class TestMarathonAcmeServer(object):
             'http://localhost/.well-known/acme-challenge/baz')
         assert_that(response, succeeded(MatchesStructure(code=Equals(404))))
 
+    def test_acme_challenge_ping(self):
+        """
+        When a GET request is made to the ACME challenge path ping endpoint,
+        a pong message should be returned.
+        """
+        response = self.client.get(
+            'http://localhost/.well-known/acme-challenge/ping')
+        assert_that(response, succeeded(MatchesAll(
+            IsJsonResponseWithCode(200),
+            After(json_content, succeeded(Equals({'message': 'pong'})))
+        )))
+
     def test_health_healthy(self):
         """
         When a GET request is made to the health endpoint, and the health


### PR DESCRIPTION
Add a way to check if marathon-acme can be reached for ACME challenges.