### PR TITLE
SseProtocol: Cancel the timeout when the connection is lost

### DIFF
--- a/marathon_acme/tests/test_sse_protocol.py
+++ b/marathon_acme/tests/test_sse_protocol.py
@@ -344,3 +344,23 @@ class TestSseProtocol(object):
 
         protocol.connectionMade()
         clock.advance(timeout)
+
+    def test_lost_connection_cancels_timeout(self):
+        """
+        When the connection is lost, the timeout should be cancelled and have
+        no effect.
+        """
+        timeout = 5
+        clock = Clock()
+        protocol = make_protocol(timeout=timeout, reactor=clock)
+        protocol.connectionMade()
+
+        assert not protocol.transport.disconnecting
+
+        # Lose the connection
+        protocol.connectionLost()
+
+        # Advance to the timeout
+        clock.advance(timeout)
+        # Timeout should *not* be triggered
+        assert not protocol.transport.disconnecting


### PR DESCRIPTION
* This is why the underlying transport was already gone when we tried
  to disconnect before. So we don't need to grab the abortConnection
  callback on connection anymore.