### PR TITLE
FakeMarathon: Use not-deprecated Twisted API

### DIFF
--- a/marathon_acme/tests/fake_marathon.py
+++ b/marathon_acme/tests/fake_marathon.py
@@ -108,12 +108,14 @@ class FakeMarathonAPI(object):
         def callback(event):
             _write_request_event(request, event)
             self.client.flush()
+        remote_address = request.getClientAddress().host
         self._marathon.attach_event_stream(
-            callback, _get_event_types(request.args), request.getClientIP())
+            callback, _get_event_types(request.args), remote_address)
         self.event_requests.append(request)
 
         def finished_errback(failure):
-            self._marathon.detach_event_stream(callback, request.getClientIP())
+            remote_address = request.getClientAddress().host
+            self._marathon.detach_event_stream(callback, remote_address)
             self.event_requests.remove(request)
 
         finished = request.notifyFinish()

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ install_requires = [
     'treq >= 17.3.1',
     # Despite treq & txacme depending on Twisted[tls], we don't get all the tls
     # extras unless we depend on the option too, I guess, because pip.
-    'Twisted[tls]',
+    'Twisted[tls] >= 18.4.0',
     'txacme >= 0.9.2',
     'uritools >= 1.0.0'
 ]


### PR DESCRIPTION
Without this we get a lot of warnings:
```
/home/travis/build/praekeltfoundation/marathon-acme/marathon_acme/tests/fake_marathon.py:112: DeprecationWarning: twisted.web.http.Request.getClientIP was deprecated in Twisted 18.4.0; please use getClientAddress instead
```