### PR TITLE
Hook up Vault in the CLI

### DIFF
--- a/marathon_acme/acme_util.py
+++ b/marathon_acme/acme_util.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime, timedelta
+from functools import partial
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -11,7 +12,6 @@ from josepy.jwk import JWKRSA
 
 from treq.client import HTTPClient
 
-from twisted.internet.defer import maybeDeferred
 from twisted.web.client import Agent
 
 from txacme.client import Client as txacme_Client, JWSClient
@@ -82,27 +82,20 @@ def maybe_key_vault(client, mount_path):
     return d.addCallback(get_or_create_key)
 
 
-def create_txacme_client_creator(reactor, url, key_func, alg=RS256):
+def create_txacme_client_creator(reactor, url, key, alg=RS256):
     """
     Create a creator for txacme clients to provide to the txacme service. See
     ``txacme.client.Client.from_url()``. We create the underlying JWSClient
     with a non-persistent pool to avoid
     https://github.com/mithrandi/txacme/issues/86.
 
-    :param key_func:
-        A 0-args callable to create a client key. May return a Deferred.
     :return: a callable that returns a deffered that returns the client
     """
-    def key_cb(key):
-        # Creating an Agent without specifying a pool gives us the default pool
-        # which is non-persistent.
-        jws_client = JWSClient(HTTPClient(agent=Agent(reactor)), key, alg)
-        return txacme_Client.from_url(reactor, url, key, alg, jws_client)
+    # Creating an Agent without specifying a pool gives us the default pool
+    # which is non-persistent.
+    jws_client = JWSClient(HTTPClient(agent=Agent(reactor)), key, alg)
 
-    def creator():
-        return maybeDeferred(key_func).addCallback(key_cb)
-
-    return creator
+    return partial(txacme_Client.from_url, reactor, url, key, alg, jws_client)
 
 
 def generate_wildcard_pem_bytes():

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -104,12 +104,6 @@ def main(reactor, argv=sys.argv[1:], env=os.environ,
 
     sse_timeout = args.sse_timeout if args.sse_timeout > 0 else None
 
-    if args.vault:
-        key_d, cert_store = init_vault_storage(
-            reactor, env, args.storage_path)
-    else:
-        key_d, cert_store = init_file_storage(args.storage_path)
-
     acme_url = URL.fromText(_to_unicode(args.acme))
 
     endpoint_description = parse_listen_addr(args.listen)
@@ -117,7 +111,7 @@ def main(reactor, argv=sys.argv[1:], env=os.environ,
     log_args = [
         ('storage-path', args.storage_path),
         ('vault', args.vault),
-        ('acme', args.acme),
+        ('acme', acme_url),
         ('email', args.email),
         ('allow-multiple-certs', args.allow_multiple_certs),
         ('marathon', marathon_addrs),
@@ -127,8 +121,14 @@ def main(reactor, argv=sys.argv[1:], env=os.environ,
         ('endpoint-description', endpoint_description),
     ]
     log_args = ['{}={!r}'.format(k, v) for k, v in log_args]
-    log.info('Running marathon-acme {} with: {}'.format(
+    log.info('Starting marathon-acme {} with: {}'.format(
         __version__, ', '.join(log_args)))
+
+    if args.vault:
+        key_d, cert_store = init_vault_storage(
+            reactor, env, args.storage_path)
+    else:
+        key_d, cert_store = init_file_storage(args.storage_path)
 
     # Once we have the client key, create the txacme client creator
     key_d.addCallback(create_txacme_client_creator, reactor, acme_url)

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -146,7 +146,7 @@ def main(reactor, argv=sys.argv[1:], env=os.environ,
 def _to_unicode(string):
     if isinstance(string, unicode):
         return string
-    return unicode(string, 'utf-8')
+    return unicode(string, sys.getfilesystemencoding())
 
 
 def parse_listen_addr(listen_addr):

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -146,8 +146,7 @@ def main(reactor, argv=sys.argv[1:], env=os.environ,
 def _to_unicode(string):
     if isinstance(string, unicode):
         return string
-    elif isinstance(string, bytes):
-        return unicode(string, 'utf-8')
+    return unicode(string, 'utf-8')
 
 
 def parse_listen_addr(listen_addr):

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import ipaddress
+import os
 import sys
 
 from twisted.internet.endpoints import quoteStringArgument
@@ -16,15 +17,18 @@ from txacme.urls import LETSENCRYPT_DIRECTORY
 
 from marathon_acme import __version__
 from marathon_acme.acme_util import (
-    create_txacme_client_creator, generate_wildcard_pem_bytes, maybe_key)
-from marathon_acme.clients import MarathonClient, MarathonLbClient
+    create_txacme_client_creator, generate_wildcard_pem_bytes, maybe_key,
+    maybe_key_vault)
+from marathon_acme.clients import MarathonClient, MarathonLbClient, VaultClient
 from marathon_acme.service import MarathonAcme
+from marathon_acme.vault_store import VaultKvCertificateStore
 
 
 log = Logger()
 
 
-def main(reactor, argv=sys.argv[1:], acme_url=LETSENCRYPT_DIRECTORY.asText()):
+def main(reactor, argv=sys.argv[1:], env=os.environ,
+         acme_url=LETSENCRYPT_DIRECTORY.asText()):
     """
     A tool to automatically request, renew and distribute Let's Encrypt
     certificates for apps running on Marathon and served by marathon-lb.
@@ -77,8 +81,16 @@ def main(reactor, argv=sys.argv[1:], acme_url=LETSENCRYPT_DIRECTORY.asText()):
                              '(default: %(default)s)',
                         choices=['debug', 'info', 'warn', 'error', 'critical'],
                         default='info'),
-    parser.add_argument('storage_dir', metavar='storage-dir',
-                        help='Path to directory for storing certificates')
+    parser.add_argument('--vault',
+                        help=('Enable storage of certificates in Vault. This '
+                              'can be further configured with VAULT_-style '
+                              'environment variables.'),
+                        action='store_true')
+    parser.add_argument('storage_path', metavar='storage-path',
+                        help=('Path for storing certificates. If --vault is '
+                              'used then this is the mount path for the '
+                              'key/value engine in Vault. If not, this is the '
+                              'path to a directory.'))
     parser.add_argument('--version', action='version', version=__version__)
 
     args = parser.parse_args(argv)
@@ -92,16 +104,19 @@ def main(reactor, argv=sys.argv[1:], acme_url=LETSENCRYPT_DIRECTORY.asText()):
 
     sse_timeout = args.sse_timeout if args.sse_timeout > 0 else None
 
-    marathon_acme = create_marathon_acme(
-        args.storage_dir, args.acme, args.email, args.allow_multiple_certs,
-        marathon_addrs, args.marathon_timeout, sse_timeout, mlb_addrs,
-        args.group, reactor)
+    if args.vault:
+        key_d, cert_store = init_vault_storage(
+            reactor, env, args.storage_path)
+    else:
+        key_d, cert_store = init_file_storage(args.storage_path)
 
-    # Run the thing
+    acme_url = URL.fromText(_to_unicode(args.acme))
+
     endpoint_description = parse_listen_addr(args.listen)
 
     log_args = [
-        ('storage-dir', args.storage_dir),
+        ('storage-path', args.storage_path),
+        ('vault', args.vault),
         ('acme', args.acme),
         ('email', args.email),
         ('allow-multiple-certs', args.allow_multiple_certs),
@@ -115,7 +130,17 @@ def main(reactor, argv=sys.argv[1:], acme_url=LETSENCRYPT_DIRECTORY.asText()):
     log.info('Running marathon-acme {} with: {}'.format(
         __version__, ', '.join(log_args)))
 
-    return marathon_acme.run(endpoint_description)
+    # Once we have the client key, create the txacme client creator
+    key_d.addCallback(create_txacme_client_creator, reactor, acme_url)
+
+    # Once we have the client creator, create the service
+    key_d.addCallback(
+        create_marathon_acme, cert_store, args.email,
+        args.allow_multiple_certs, marathon_addrs, args.marathon_timeout,
+        sse_timeout, mlb_addrs, args.group, reactor)
+
+    # Finally, run the thing
+    return key_d.addCallback(lambda ma: ma.run(endpoint_description))
 
 
 def _to_unicode(string):
@@ -166,15 +191,16 @@ def _create_tx_endpoints_string(args, kwargs):
 
 
 def create_marathon_acme(
-    storage_dir, acme_directory, acme_email, allow_multiple_certs,
+    client_creator, cert_store, acme_email, allow_multiple_certs,
     marathon_addrs, marathon_timeout, sse_timeout, mlb_addrs, group,
         reactor):
     """
     Create a marathon-acme instance.
 
-    :param storage_dir:
-        Path to the storage directory for certificates and the client key.
-    :param acme_directory: Address for the ACME directory to use.
+    :param client_creator:
+        The txacme client creator function.
+    :param cert_store:
+        The txacme certificate store instance.
     :param acme_email:
         Email address to use when registering with the ACME service.
     :param allow_multiple_certs:
@@ -196,20 +222,21 @@ def create_marathon_acme(
         app domains.
     :param reactor: The reactor to use.
     """
-    storage_path, certs_path = init_storage_dir(storage_dir)
-    acme_url = URL.fromText(_to_unicode(acme_directory))
-    key = maybe_key(storage_path)
+    marathon_client = MarathonClient(marathon_addrs, timeout=marathon_timeout,
+                                     sse_kwargs={'timeout': sse_timeout},
+                                     reactor=reactor)
+    marathon_lb_client = MarathonLbClient(mlb_addrs, reactor=reactor)
 
     return MarathonAcme(
-        MarathonClient(marathon_addrs, timeout=marathon_timeout,
-                       sse_kwargs={'timeout': sse_timeout}, reactor=reactor),
+        marathon_client,
         group,
-        DirectoryStore(certs_path),
-        MarathonLbClient(mlb_addrs, reactor=reactor),
-        create_txacme_client_creator(reactor, acme_url, key),
+        cert_store,
+        marathon_lb_client,
+        client_creator,
         reactor,
         acme_email,
-        allow_multiple_certs)
+        allow_multiple_certs
+    )
 
 
 def init_storage_dir(storage_dir):
@@ -255,6 +282,20 @@ def init_logging(log_level):
     log_observer = FilteringLogObserver(
         textFileLogObserver(sys.stdout), [log_level_filter])
     globalLogPublisher.addObserver(log_observer)
+
+
+def init_vault_storage(reactor, env, mount_path):
+    vault_client = VaultClient.from_env(reactor=reactor, env=env)
+    cert_store = VaultKvCertificateStore(vault_client, mount_path)
+    key_d = maybe_key_vault(vault_client, mount_path)
+    return key_d, cert_store
+
+
+def init_file_storage(storage_dir):
+    storage_path, certs_path = init_storage_dir(storage_dir)
+    cert_store = DirectoryStore(certs_path)
+    key_d = maybe_key(storage_path)
+    return key_d, cert_store
 
 
 def _main():  # pragma: no cover

--- a/marathon_acme/cli.py
+++ b/marathon_acme/cli.py
@@ -198,8 +198,7 @@ def create_marathon_acme(
     """
     storage_path, certs_path = init_storage_dir(storage_dir)
     acme_url = URL.fromText(_to_unicode(acme_directory))
-    client_creator = create_txacme_client_creator(
-        reactor, acme_url, lambda: maybe_key(storage_path))
+    key = maybe_key(storage_path)
 
     return MarathonAcme(
         MarathonClient(marathon_addrs, timeout=marathon_timeout,
@@ -207,7 +206,7 @@ def create_marathon_acme(
         group,
         DirectoryStore(certs_path),
         MarathonLbClient(mlb_addrs, reactor=reactor),
-        client_creator,
+        create_txacme_client_creator(reactor, acme_url, key),
         reactor,
         acme_email,
         allow_multiple_certs)

--- a/marathon_acme/tests/test_acme_util.py
+++ b/marathon_acme/tests/test_acme_util.py
@@ -52,7 +52,7 @@ class TestMaybeKey(object):
         pem_file.setContent(_dump_pem_private_key_bytes(raw_key))
 
         actual_key = maybe_key(pem_path)
-        assert_that(actual_key, Equals(expected_key))
+        assert_that(actual_key, succeeded(Equals(expected_key)))
 
     def test_key_not_exists(self, pem_path):
         """
@@ -67,7 +67,7 @@ class TestMaybeKey(object):
         file_key = _load_pem_private_key_bytes(pem_file.getContent())
         file_key = JWKRSA(key=file_key)
 
-        assert_that(key, Equals(file_key))
+        assert_that(key, succeeded(Equals(file_key)))
 
 
 class TestMaybeKeyVault(object):

--- a/marathon_acme/tests/test_cli.py
+++ b/marathon_acme/tests/test_cli.py
@@ -7,7 +7,7 @@ from testtools.assertions import assert_that
 from testtools.matchers import (
     Contains, DirExists, Equals, FileContains, FileExists, MatchesStructure)
 from testtools.twistedsupport import (
-    AsynchronousDeferredRunTest, flush_logged_errors, failed)
+    AsynchronousDeferredRunTest, flush_logged_errors)
 
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
@@ -16,7 +16,6 @@ from twisted.internet.error import CannotListenError, ConnectionRefusedError
 from txacme.urls import LETSENCRYPT_STAGING_DIRECTORY
 
 from marathon_acme.cli import init_storage_dir, main, parse_listen_addr
-from marathon_acme.tests.matchers import WithErrorTypeAndMessage
 
 
 # Make sure we always use the Let's Encrypt Staging endpoint for these tests

--- a/marathon_acme/tests/test_cli.py
+++ b/marathon_acme/tests/test_cli.py
@@ -133,7 +133,7 @@ class TestParseListenAddr(object):
         with ExpectedException(
             ValueError,
             r"'foobar' does not have the correct form for a listen address: "
-                '\[ipaddress\]:port'):
+                r'\[ipaddress\]:port'):
             parse_listen_addr('foobar')
 
     def test_parse_no_ip_address(self):
@@ -158,7 +158,7 @@ class TestParseListenAddr(object):
         interface is present in the returned endpoint description.
         """
         assert_that(parse_listen_addr('[::]:8080'),
-                    Equals('tcp6:8080:interface=\:\:'))
+                    Equals('tcp6:8080:interface=\\:\\:'))
 
     def test_parse_invalid_ipaddress(self):
         """


### PR DESCRIPTION
I reverted 3e6256bd3ef9f1c98eb8768d69cc36f83bda1c05 because there were two problems with it:
 1. txacme calls the client creator each time it performs any ACME API operation, causing us to fetch/read the client key for each API call.
 2. Errors fetching or storing the client key were kind of swallowed--the txacme service would have an error but things would otherwise continue. Now we don't start up txacme or marathon-acme at all if we can't fetch/store the client key.